### PR TITLE
Correct types to match libgbinder headers to fix 32-bit compiles

### DIFF
--- a/cgbinder.pxd
+++ b/cgbinder.pxd
@@ -40,6 +40,8 @@ cdef extern from "gbinder/gbinder_types.h":
 
     ctypedef GBinderLocalReply* (*GBinderLocalTransactFunc)(GBinderLocalObject* obj, GBinderRemoteRequest* req, unsigned int code, unsigned int flags, int* status, void* user_data)
 
+from libc.stdint cimport int64_t, uint64_t
+
 cdef extern from "gbinder/gbinder_servicemanager.h":
     ctypedef void (*GBinderServiceManagerFunc)(GBinderServiceManager* sm, void* user_data)
     ctypedef bint (*GBinderServiceManagerListFunc)(GBinderServiceManager* sm, char** services, void* user_data)
@@ -162,8 +164,8 @@ cdef extern from "gbinder/gbinder_reader.h":
     bint gbinder_reader_read_bool(GBinderReader* reader, bint* value)
     bint gbinder_reader_read_int32(GBinderReader* reader, signed int* value)
     bint gbinder_reader_read_uint32(GBinderReader* reader, unsigned int* value)
-    bint gbinder_reader_read_int64(GBinderReader* reader, signed long* value)
-    bint gbinder_reader_read_uint64(GBinderReader* reader, unsigned long* value)
+    bint gbinder_reader_read_int64(GBinderReader* reader, int64_t* value)
+    bint gbinder_reader_read_uint64(GBinderReader* reader, uint64_t* value)
     bint gbinder_reader_read_float(GBinderReader* reader, float* value)
     bint gbinder_reader_read_double(GBinderReader* reader, double* value)
     int gbinder_reader_read_fd(GBinderReader* reader)
@@ -174,8 +176,8 @@ cdef extern from "gbinder/gbinder_reader.h":
     GBinderBuffer* gbinder_reader_read_buffer(GBinderReader* reader)
 
     const void* gbinder_reader_read_hidl_struct1(GBinderReader* reader, unsigned long size)
-    const void* gbinder_reader_read_hidl_vec(GBinderReader* reader, unsigned long* count, unsigned long* elemsize)
-    const void* gbinder_reader_read_hidl_vec1(GBinderReader* reader, unsigned long* count, unsigned int expected_elemsize)
+    const void* gbinder_reader_read_hidl_vec(GBinderReader* reader, size_t* count, size_t* elemsize)
+    const void* gbinder_reader_read_hidl_vec1(GBinderReader* reader, size_t* count, unsigned int expected_elemsize)
     char* gbinder_reader_read_hidl_string(GBinderReader* reader)
     const char* gbinder_reader_read_hidl_string_c(GBinderReader* reader)
     char** gbinder_reader_read_hidl_string_vec(GBinderReader* reader)
@@ -188,7 +190,7 @@ cdef extern from "gbinder/gbinder_reader.h":
     #bint gbinder_reader_read_nullable_string16_utf16(GBinderReader* reader, const unsigned short** out, unsigned long* len)
     #const unsigned short* gbinder_reader_read_string16_utf16(GBinderReader* reader,unsigned long* len)
     bint gbinder_reader_skip_string16(GBinderReader* reader)
-    const void* gbinder_reader_read_byte_array(GBinderReader* reader, unsigned long* len)
+    const void* gbinder_reader_read_byte_array(GBinderReader* reader, size_t* len)
     unsigned long gbinder_reader_bytes_read(const GBinderReader* reader)
     unsigned long gbinder_reader_bytes_remaining(const GBinderReader* reader)
     #void gbinder_reader_copy(GBinderReader* dest, const GBinderReader* src)
@@ -212,8 +214,8 @@ cdef extern from "gbinder/gbinder_remote_reply.h":
 
     bint gbinder_remote_reply_read_int32(GBinderRemoteReply* reply, signed int* value)
     bint gbinder_remote_reply_read_uint32(GBinderRemoteReply* reply, unsigned int* value)
-    bint gbinder_remote_reply_read_int64(GBinderRemoteReply* reply, signed long* value)
-    bint gbinder_remote_reply_read_uint64(GBinderRemoteReply* reply, unsigned long* value)
+    bint gbinder_remote_reply_read_int64(GBinderRemoteReply* reply, int64_t* value)
+    bint gbinder_remote_reply_read_uint64(GBinderRemoteReply* reply, uint64_t* value)
     const char* gbinder_remote_reply_read_string8(GBinderRemoteReply* reply)
     char* gbinder_remote_reply_read_string16(GBinderRemoteReply* reply)
     GBinderRemoteObject* gbinder_remote_reply_read_object(GBinderRemoteReply* reply)
@@ -232,8 +234,8 @@ cdef extern from "gbinder/gbinder_remote_request.h":
 
     bint gbinder_remote_request_read_int32(GBinderRemoteRequest* req, signed int* value)
     bint gbinder_remote_request_read_uint32(GBinderRemoteRequest* req, unsigned int* value)
-    bint gbinder_remote_request_read_int64(GBinderRemoteRequest* req, signed long* value)
-    bint gbinder_remote_request_read_uint64(GBinderRemoteRequest* req, unsigned long* value)
+    bint gbinder_remote_request_read_int64(GBinderRemoteRequest* req, int64_t* value)
+    bint gbinder_remote_request_read_uint64(GBinderRemoteRequest* req, uint64_t* value)
     const char* gbinder_remote_request_read_string8(GBinderRemoteRequest* req)
     char* gbinder_remote_request_read_string16(GBinderRemoteRequest* req)
     GBinderRemoteObject* gbinder_remote_request_read_object(GBinderRemoteRequest* self)

--- a/gbinder.pyx
+++ b/gbinder.pyx
@@ -68,6 +68,8 @@ cdef class RemoteObject:
 cdef void remote_object_local_notify_func(cgbinder.GBinderRemoteObject* obj, void* user_data) noexcept with gil:
     (<object>user_data).notify_func_callback()
 
+from libc.stdint cimport int64_t, uint64_t
+
 cdef class RemoteReply:
     cdef cgbinder.GBinderRemoteReply* _reply
 
@@ -114,7 +116,7 @@ cdef class RemoteReply:
     def read_int64(self):
         if self._reply is NULL:
             return None
-        cdef signed long value
+        cdef int64_t value
         cdef bint status
         status = cgbinder.gbinder_remote_reply_read_int64(self._reply, &value)
         return status, value
@@ -122,7 +124,7 @@ cdef class RemoteReply:
     def read_uint64(self):
         if self._reply is NULL:
             return None
-        cdef unsigned long value
+        cdef uint64_t value
         cdef bint status
         status = cgbinder.gbinder_remote_reply_read_uint64(self._reply, &value)
         return status, value
@@ -441,7 +443,7 @@ cdef class RemoteRequest:
     def read_int64(self):
         if self._req is NULL:
             return None
-        cdef signed long value
+        cdef int64_t value
         cdef bint status
         status = cgbinder.gbinder_remote_request_read_int64(self._req, &value)
         return status, value
@@ -449,7 +451,7 @@ cdef class RemoteRequest:
     def read_uint64(self):
         if self._req is NULL:
             return None
-        cdef unsigned long value
+        cdef uint64_t value
         cdef bint status
         status = cgbinder.gbinder_remote_request_read_uint64(self._req, &value)
         return status, value
@@ -836,13 +838,13 @@ cdef class Reader:
         return status, value
 
     def read_int64(self):
-        cdef signed long value
+        cdef int64_t value
         cdef bint status
         status = cgbinder.gbinder_reader_read_int64(&self._reader, &value)
         return status, value
 
     def read_uint64(self):
-        cdef unsigned long value
+        cdef uint64_t value
         cdef bint status
         status = cgbinder.gbinder_reader_read_uint64(&self._reader, &value)
         return status, value
@@ -890,12 +892,12 @@ cdef class Reader:
         return <object>value
 
     def read_hidl_vec(self):
-        cdef unsigned long count, elemsize
+        cdef size_t count, elemsize
         cdef const void* value = cgbinder.gbinder_reader_read_hidl_vec(&self._reader, &count, &elemsize)
         return <object>value, count, elemsize
 
     def read_hidl_vec1(self, unsigned int expected_elemsize):
-        cdef unsigned long count
+        cdef size_t count
         cdef const void* value = cgbinder.gbinder_reader_read_hidl_vec1(&self._reader, &count, expected_elemsize)
         return <object>value, count
 
@@ -931,7 +933,7 @@ cdef class Reader:
         return cgbinder.gbinder_reader_skip_string16(&self._reader)
 
     def read_byte_array(self):
-        cdef unsigned long len
+        cdef size_t len
         cdef const void* value = cgbinder.gbinder_reader_read_byte_array(&self._reader, &len)
         return <object>value, len
 


### PR DESCRIPTION
Use `int64_t`, `uint64_t` and `size_t` to (more) properly match [the Glib types](https://docs.gtk.org/glib/types.html) used in libgbinder headers themselves.

Fixes #18.